### PR TITLE
[FIX] Description Under Overview Action Showing null

### DIFF
--- a/github/lib/repoDataMessage.ts
+++ b/github/lib/repoDataMessage.ts
@@ -64,6 +64,12 @@ export async function repoDataMessage({
         });
     }
 
+    let description: string | null = resData.description;
+
+    if(description === null){
+        description = 'No description provided.';
+    }
+
     const textSender = await modify
         .getCreator()
         .startMessage()
@@ -72,9 +78,9 @@ export async function repoDataMessage({
                 stars +
                 issues +
                 forks +
-                "```" +
-                resData.description +
-                "```" +
+                "`" +
+                description +
+                "`" +
                 tags
         );
     if (room) {

--- a/github/lib/repoDataMessage.ts
+++ b/github/lib/repoDataMessage.ts
@@ -64,11 +64,7 @@ export async function repoDataMessage({
         });
     }
 
-    let description: string | null = resData.description;
-
-    if(description === null){
-        description = 'No description provided.';
-    }
+    const description = resData.description || 'No description provided.';
 
     const textSender = await modify
         .getCreator()


### PR DESCRIPTION
## Issue(s) 

Closes #38 

##  Fixed Bugs
- [x] Removed redundant backticks around the description and tags under Overview of Repository
- [x] `No description provided` text instead of `null` when the repository doesn't have a description.

![Screenshot from 2022-12-04 16-13-04](https://user-images.githubusercontent.com/65061890/205488467-f568a5df-cff8-4f5d-aa55-9639b895f926.png)
