### PR TITLE
fix: `/gh issues` unrecognised by command utility

### DIFF
--- a/github/handlers/HandleIssues.ts
+++ b/github/handlers/HandleIssues.ts
@@ -5,6 +5,7 @@ import { GithubApp } from "../GithubApp";
 import { sendNotification } from "../lib/message";
 import { NewIssueStarterModal } from "../modals/newIssueStarterModal";
 import { getAccessTokenForUser } from "../persistance/auth";
+import { GitHubIssuesStarterModal } from "../modals/getIssuesStarterModal";
 
 export async function handleNewIssue(
     read: IRead,
@@ -49,4 +50,23 @@ export async function handleNewIssue(
             "Login to subscribe to repository events ! `/github login`"
         );
     }
+}
+
+export async function handleIssues(
+    read: IRead,
+    context: SlashCommandContext,
+    app: GithubApp,
+    persistence: IPersistence,
+    http: IHttp,
+    room: IRoom,
+    modify: IModify
+){
+    const triggerId= context.getTriggerId();
+    if(triggerId){
+        const modal = await GitHubIssuesStarterModal({modify,read,persistence,http,slashcommandcontext:context});
+        await modify.getUiController().openModalView(modal,{triggerId},context.getSender());
+    }else{
+        console.log("Inavlid Trigger ID !");
+    }
+
 }

--- a/github/lib/commandUtility.ts
+++ b/github/lib/commandUtility.ts
@@ -21,7 +21,7 @@ import {
     ManageSubscriptions,
 } from "../handlers/EventHandler";
 import { handleSearch } from "../handlers/SearchHandler";
-import { handleNewIssue } from "../handlers/HandleNewIssue";
+import { handleIssues, handleNewIssue } from "../handlers/HandleIssues";
 import { handleUserProfileRequest } from "../handlers/UserProfileHandler";
 
 export class CommandUtility implements ExecutorProps {
@@ -136,6 +136,18 @@ export class CommandUtility implements ExecutorProps {
                         this.room,
                         this.modify
                     );
+                    break;
+                }
+                case SubcommandEnum.ISSUES :{
+                    handleIssues(
+                        this.read,
+                        this.context,
+                        this.app,
+                        this.persistence,
+                        this.http,
+                        this.room,
+                        this.modify
+                    )
                     break;
                 }
                 default: {


### PR DESCRIPTION
## Issue(s) 
The issues modal triggered by `/gh issues`, showing the current issues of a given respository was implemented but the case for triggering the same from command utility was not handled.

## Acceptance Criteria fulfillment

- [x] Make a new function in `IssuesHandler` for launching the `issues` modal, named as `handleIssues`
- [x] Trigger the above mentioned function in singular param commands in the command utility on case `SubcommandEnum.Issues`

## Proposed changes (including videos or screenshots)

https://user-images.githubusercontent.com/72302948/220573788-6390d57e-d0de-4767-9bcd-a6204f42c50b.mov


