### PR TITLE
[FIX] subscribeall doesn't provide info when not loggedIn

### DIFF
--- a/github/handlers/EventHandler.ts
+++ b/github/handlers/EventHandler.ts
@@ -118,6 +118,14 @@ export async function SubscribeAllEvents(
         } catch (error) {
             console.log("SubcommandError", error);
         }
+    } else {
+        await sendNotification(
+            read,
+            modify,
+            context.getSender(),
+            room,
+            "Login to subscribe to repository events ! `/github login`"
+        );
     }
 }
 


### PR DESCRIPTION
## Issue(s) 
Closes #64 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criterias required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteriasd are provided -->


## Proposed changes (including videos or screenshots)
- Now that when non-authorised user will run the command `/github username/repo subscribe` will provide the login info notification.
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->