### PR TITLE
[Fix] GitHub Caching rendering outdated SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The GitHub Rocket.Chat App provides a seamless integration between GitHub and Ro
 
 <div align='center' width='100%'>
 <a href="https://www.middlewarehq.com/">
-<img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-Apps.Github22-contributor-metrics-dark-widget.svg?metrics=true"></img>
+<img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-Apps.Github22-contributor-metrics-dark-widget.svg?caching=false"></img>
 </a>
 </div>
 


### PR DESCRIPTION
## Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criterias required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteriasd are provided -->

- [x] Updated the served widgets headers to avoid GitHub caching outdated SVGs. Adding a updated url so that GitHub can render and update the widget based on the updated headers.

## Proposed changes (including videos or screenshots)

- The current caching mechanism by our CDN which was serving the contributor metrics widget did not provide a Cache-Control : max-age header value to GitHub. This lead to GitHub caching the widget svg forever, leading to old data. 
- We have updated the headers and set max-age to two hours. 
- Updated the url to render updated widget. 

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->