### PR TITLE
Create issue action button

### DIFF
--- a/github/app.json
+++ b/github/app.json
@@ -8,6 +8,53 @@
         "homepage": "https://github.com/samad-yar-khan",
         "support": "https://github.com/samad-yar-khan"
     },
+    "permissions": [
+        {
+            "name": "ui.registerButtons"
+        },
+        {
+            "name": "api"
+        },
+        {
+            "name": "slashcommand"
+        },
+        {
+            "name": "scheduler"
+        },
+        {
+            "name": "server-setting.read"
+        },
+        {
+            "name": "server-setting.write"
+        },
+        {
+            "name": "room.read"
+        },
+        {
+            "name": "room.write"
+        },
+        {
+            "name": "message.read"
+        },
+        {
+            "name": "message.write"
+        },
+        {
+            "name": "ui.interact"
+        },
+        {
+            "name": "persistence"
+        },
+        {
+            "name": "networking"
+        },
+        {
+            "name": "user.read"
+        },
+        {
+            "name": "user.write"
+        }
+    ],
     "name": "Github",
     "nameSlug": "github",
     "classFile": "GithubApp.ts",

--- a/github/handlers/executeActionButtonHandler.ts
+++ b/github/handlers/executeActionButtonHandler.ts
@@ -1,0 +1,92 @@
+import { IRead, IHttp, IModify, IPersistence } from "@rocket.chat/apps-engine/definition/accessors";
+import { BlockType, IImageBlock, IImageElement, IUIKitResponse, UIKitActionButtonInteractionContext } from "@rocket.chat/apps-engine/definition/uikit";
+import { ModalsEnum } from "../enum/Modals";
+import { GithubApp } from "../GithubApp";
+import { NewIssueModal } from "../modals/newIssueModal";
+
+export class ExecuteButtonActionHandler {
+    constructor(
+        private readonly app: GithubApp,
+        private readonly read: IRead,
+        private readonly http: IHttp,
+        private readonly modify: IModify,
+        private readonly persistence: IPersistence
+    ) { }
+
+    public async run(
+        context: UIKitActionButtonInteractionContext
+    ): Promise<IUIKitResponse>{
+        const data = context.getInteractionData();
+
+        try {
+            const { actionId } = data;
+            switch (actionId) {
+                case ModalsEnum.NEW_ISSUE_ACTION: {
+                    const { message, user, room } = data;
+
+                    let modalData;
+                    if (message && (message.text || message.attachments)){
+
+                        // TODO We need to download and upload the files to github first, else rocket.chat won't allow accessing images like below
+                        // const attachmentImageURLs: String[] = []
+                        // const attachmentVideoURLs: String[] = []
+                        // const settings = this.read.getEnvironmentReader().getServerSettings();
+                        // const Site_Url = await settings.getValueById("Site_Url");
+                        // if (message.attachments){
+                        //     message.attachments.map((attachment) => {
+                        //         if (attachment.imageUrl){
+                        //             attachmentImageURLs.push(`### ${attachment.description?.split("|").pop()}\n![image](${Site_Url}/${attachment.imageUrl})`)
+                        //         }
+                        //         if (attachment.videoUrl){
+                        //             attachmentVideoURLs.push(`### ${attachment.description?.split("|").pop()}\n` + `${Site_Url}/${attachment.videoUrl}`)
+                        //         }
+                        //     })
+                        // }
+
+                        // if (message.blocks){
+                        //     message.blocks.map((element) => {
+                        //         if (element.type === BlockType.IMAGE){
+                        //             element = element as IImageElement
+                        //             attachmentImageURLs.push(`### ${element.altText}\n![image](${element.imageUrl})`)
+                        //         }
+                        //     })
+                        // }
+
+                        // Taking Repository and Body Seperated By Pipe Operator
+                        let pieces = message.text ? message.text.split("|") : [""]
+
+                        if (message.text === '' && message.attachments){
+                            if (message.attachments[0].description){
+                                pieces = message.attachments[0].description.split("|")
+                            }
+                        }
+                        
+
+                        modalData = {
+                            repository: pieces.length === 2 ? pieces[0] : undefined,
+                            template : pieces.length === 2 ? pieces[1] : pieces[0]
+                            // template : (pieces.length === 2 ? pieces[1] : pieces[0]) + (attachmentImageURLs.length !== 0 ? "\n## Screenshots\n" + attachmentImageURLs.join("\n") : "") + (attachmentVideoURLs.length !== 0 ? "\n## Videos\n" + attachmentVideoURLs.join("\n") : "" )
+                        }
+                    }
+
+                    const modal = await NewIssueModal({
+                        data: modalData,
+                        modify: this.modify,
+                        read: this.read,
+                        persistence: this.persistence,
+                        http: this.http,
+                        user: user,
+                        room: room,
+                    })
+
+                    return context.getInteractionResponder().openModalViewResponse(modal)
+                }
+
+            }
+        } catch (error){
+            console.log(error)
+        }
+
+        return context.getInteractionResponder().successResponse()
+    }
+}

--- a/github/i18n/en.json
+++ b/github/i18n/en.json
@@ -1,3 +1,4 @@
 {
-    "cmd_description": "Search, Share, Review, Merge, Subscribe GitHub Resources and do much more from Rocket.Chat."
+    "cmd_description": "Search, Share, Review, Merge, Subscribe GitHub Resources and do much more from Rocket.Chat.",
+    "open_issue_message": "🎈 Open Github Issue"
 }

--- a/github/modals/newIssueModal.ts
+++ b/github/modals/newIssueModal.ts
@@ -18,6 +18,7 @@ import {
     storeInteractionRoomData,
     getInteractionRoomData,
 } from "../persistance/roomInteraction";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 
 export async function NewIssueModal({
     data,
@@ -25,6 +26,8 @@ export async function NewIssueModal({
     read,
     persistence,
     http,
+    user,
+    room,
     slashcommandcontext,
     uikitcontext,
 }: {
@@ -33,13 +36,19 @@ export async function NewIssueModal({
     read: IRead;
     persistence: IPersistence;
     http: IHttp;
+    user?: IUser,
+    room? : IRoom,
     slashcommandcontext?: SlashCommandContext;
     uikitcontext?: UIKitInteractionContext;
 }): Promise<IUIKitModalViewParam> {
     const viewId = ModalsEnum.NEW_ISSUE_VIEW;
     const block = modify.getCreator().getBlockBuilder();
-    const room = slashcommandcontext?.getRoom() || uikitcontext?.getInteractionData().room;
-    const user = slashcommandcontext?.getSender() || uikitcontext?.getInteractionData().user;
+    if (user == undefined && slashcommandcontext != undefined){
+        user = slashcommandcontext?.getSender() || uikitcontext?.getInteractionData().user;
+    }
+    if (room == undefined && slashcommandcontext != undefined){
+        room = slashcommandcontext?.getRoom() || uikitcontext?.getInteractionData().room;
+    }
 
     if (user?.id) {
         let roomId;
@@ -88,7 +97,7 @@ export async function NewIssueModal({
                 }),
             });
         }
-        
+
 
         block.addInputBlock({
             blockId: ModalsEnum.ISSUE_TITLE_INPUT,

--- a/github/package.json
+++ b/github/package.json
@@ -3,6 +3,7 @@
         "@rocket.chat/apps-engine": "^1.36.0",
         "@types/node": "14.14.6",
         "tslint": "^5.10.0",
-        "typescript": "^4.0.5"
+        "typescript": "^4.0.5",
+        "@rocket.chat/ui-kit": "^0.31.22"
     }
 }


### PR DESCRIPTION
Closes #87 

## Issue(s) 
Many of the times, customers tend to share their queries directly in the chat, such as reporting a bug or something like a feature request, adding an action button in the list of actions beside a message that pops up a modal which helps in opening an issue can be a very good addition for a user convenience.

## Acceptance Criteria fulfillment

- [x] Register the action button, in Command's Main Function.
- [x] Make Action Handler to the Button and check for auth.
- [x] Modify the New User Modal, for shared support for both `SlashCommandContext` and also with `Action Button Context`
- [x] Launch the Modal with `message.text` as `data.template` for the `NewIssueModal`

## Shortcuts
- Use your message text in the format to embed repository name in the modal as well `<owner/repositor> | <issue>`, this will take the repository name and pass it to modal with the issue text as well

## Proposed changes 
### Issue Button
<img width="1332" alt="Hello" src="https://user-images.githubusercontent.com/72302948/229091172-4a2025d2-fd40-4c07-b2f4-f0e371b811cb.png">

### Issue without shortcut
![NewIssueCreation](https://user-images.githubusercontent.com/72302948/229092576-28f6bb3c-ed21-4278-94c5-d6c35981a1cb.gif)
### Issue with shortcut
![NewIssueCreationShortcut](https://user-images.githubusercontent.com/72302948/229093064-e6c3d920-736d-4e31-a4be-f5e245a48968.gif)
