### PR TITLE
Adding issue contextual bar

### DIFF
--- a/github/ContextualBars/UserIssuesContextualBar.ts
+++ b/github/ContextualBars/UserIssuesContextualBar.ts
@@ -11,7 +11,7 @@ import {
     TextObjectType,
     UIKitInteractionContext,
 } from "@rocket.chat/apps-engine/definition/uikit";
-import { IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
+import { IUIKitContextualBarViewParam, IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
 import { ModalsEnum } from "../enum/Modals";
 import { OcticonIcons } from "../enum/OcticonIcons";
 import { getBasicUserInfo, getUserAssignedIssues } from "../helpers/githubSDK";
@@ -20,7 +20,7 @@ import {
     storeInteractionRoomData,
 } from "../persistance/roomInteraction";
 
-export async function userIssuesModal({
+export async function userIssuesContextualBar({
     filter,
     access_token,
     modify,
@@ -42,7 +42,8 @@ export async function userIssuesModal({
     http: IHttp;
     slashcommandcontext?: SlashCommandContext;
     uikitcontext?: UIKitInteractionContext;
-}): Promise<IUIKitModalViewParam> {
+}): Promise<IUIKitContextualBarViewParam> {
+
     const viewId = ModalsEnum.USER_ISSUE_VIEW;
     const block = modify.getCreator().getBlockBuilder();
     const room =

--- a/github/enum/Modals.ts
+++ b/github/enum/Modals.ts
@@ -17,7 +17,7 @@ export enum ModalsEnum {
     MENTIONED_ISSUE_FILTER = 'mentioned',
     SWITCH_ISSUE_FILTER = 'switch-issue-filter',
     USER_ISSUE_VIEW = 'user-issue-view',
-    TRIGGER_ISSUES_MODAL = 'trigger-issue-modal',
+    TRIGGER_ISSUES_CONTEXTUAL_BAR = 'trigger-issue-modal',
     TRIGGER_REPOS_MODAL = 'trigger-repos-modal',
     TRIGGER_ACTIVITY_MODAL = 'trigger-activity-modal',
     TRIGGER_NOTIFICATIONS_MODAL = 'trigger-notifications-modal',

--- a/github/handlers/ExecuteBlockActionHandler.ts
+++ b/github/handlers/ExecuteBlockActionHandler.ts
@@ -1,11 +1,9 @@
 import {
     IHttp,
-    ILogger,
     IModify,
     IPersistence,
     IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
-import { IApp } from "@rocket.chat/apps-engine/definition/IApp";
 import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 import { basicQueryMessage } from "../helpers/basicQueryMessage";
 import { ModalsEnum } from "../enum/Modals";
@@ -43,7 +41,7 @@ import { GithubRepoIssuesStorage } from "../persistance/githubIssues";
 import { IGitHubIssueData } from "../definitions/githubIssueData";
 import { shareProfileModal } from "../modals/profileShareModal";
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from "@rocket.chat/apps-engine/definition/metadata";
-import { userIssuesModal } from "../modals/UserIssuesModal";
+import { userIssuesContextualBar } from "../ContextualBars/UserIssuesContextualBar";
 import { IssueDisplayModal } from "../modals/IssueDisplayModal";
 import { IGitHubIssue } from "../definitions/githubIssue";
 import { BodyMarkdownRenderer } from "../processors/bodyMarkdowmRenderer";
@@ -179,7 +177,7 @@ export class ExecuteBlockActionHandler {
                         uikitcontext : context
                     })
 
-                    return context.getInteractionResponder().updateModalViewResponse(issueDisplayModal);
+                    return context.getInteractionResponder().openContextualBarViewResponse(issueDisplayModal);
                 }
                 case ModalsEnum.SWITCH_ISSUE_SORT :
                 case ModalsEnum.SWITCH_ISSUE_STATE :
@@ -236,7 +234,7 @@ export class ExecuteBlockActionHandler {
                     }
 
                     let access_token = await getAccessTokenForUser(this.read, user, this.app.oauth2Config) as IAuthData;
-                    const issueModal = await userIssuesModal({
+                    const issuesContextualBar = await userIssuesContextualBar({
                         access_token : access_token.token,
                         filter : filter,
                         modify : this.modify,
@@ -247,9 +245,9 @@ export class ExecuteBlockActionHandler {
 
                     await this.persistence.updateByAssociation(record, filter);
 
-                    return context.getInteractionResponder().updateModalViewResponse(issueModal);
+                    return context.getInteractionResponder().updateContextualBarViewResponse(issuesContextualBar);
                 }
-                case ModalsEnum.TRIGGER_ISSUES_MODAL : {
+                case ModalsEnum.TRIGGER_ISSUES_CONTEXTUAL_BAR : {
 
                     const {user} = context.getInteractionData();
 
@@ -261,7 +259,7 @@ export class ExecuteBlockActionHandler {
                         sort : ModalsEnum.ISSUE_SORT_CREATED
                     }
 
-                    const issuesModal = await userIssuesModal({
+                    const issuesContextualBar = await userIssuesContextualBar({
                         filter : filter,
                         access_token : access_token.token,
                         modify: this.modify,
@@ -271,7 +269,7 @@ export class ExecuteBlockActionHandler {
                         uikitcontext : context
                     });
 
-                    return context.getInteractionResponder().openModalViewResponse(issuesModal);
+                    return context.getInteractionResponder().openContextualBarViewResponse(issuesContextualBar);
                 }
                 case ModalsEnum.TRIGGER_REPOS_MODAL : {
                     break;

--- a/github/modals/UserProfileModal.ts
+++ b/github/modals/UserProfileModal.ts
@@ -91,7 +91,7 @@ export async function userProfileModal({
             }),
             block.newButtonElement(
                 {
-                    actionId: ModalsEnum.TRIGGER_ISSUES_MODAL,
+                    actionId: ModalsEnum.TRIGGER_ISSUES_CONTEXTUAL_BAR,
                     value: "Trigger Issues Modal",
                     text: {
                         type: TextObjectType.PLAINTEXT,
@@ -110,7 +110,7 @@ export async function userProfileModal({
             type: TextObjectType.PLAINTEXT,
             text: userInfo.name
         },
-        blocks: block.getBlocks()
+        blocks: block.getBlocks(),
     }
 
 }

--- a/github/package.json
+++ b/github/package.json
@@ -3,6 +3,7 @@
         "@rocket.chat/apps-engine": "^1.36.0",
         "@types/node": "14.14.6",
         "tslint": "^5.10.0",
-        "typescript": "^4.0.5"
+        "typescript": "^4.0.5",
+        "@rocket.chat/ui-kit": "^0.31.22"
     }
 }


### PR DESCRIPTION
Closes #94 

## Issue(s) 
We have a button in UserProfileView, which tends to open user's issues, with it's states of mentioned / created and open / close, but the supporting SurfaceView that lists the issues is a ModalView which is not the best solution to display list like data, hence I request to switch to Contextual Bar View, which doesn't block user's activity while working on any chat and keeps the issues handy in contextual bar.

## Acceptance Criteria fulfillment

- [x] Replace UserIssuesModal with UserIssuesContextualBar under a new Directory with Contextual Bars.
- [x] Update ContextualBar Actions that updated the Current Modal to updating the current contextual bar.

## Proposed changes (including videos or screenshots)
![IssueListContextualBar](https://user-images.githubusercontent.com/72302948/229307680-30240a88-4f6a-4e04-9c0d-effa0954ff6f.gif)
