### PR TITLE
[FEAT]: Add remove and open button in reminder's modal 

### DIFF
--- a/github/enum/Modals.ts
+++ b/github/enum/Modals.ts
@@ -214,5 +214,8 @@ export enum ModalsEnum {
     MAIN_MODAL_ASSIGN_ISSUES_DESCRIPTION = "Assign issues to your team members",
     NEW_REMINDER_VIEW = "new-reminder-view",
     UNSUBSCRIBE_REMINDER_ACTION = "unsubscribe-reminder-action",
-    REMINDER_LIST_MODAL_VIEW= "reminder-list-view"
+    REMINDER_LIST_MODAL_VIEW= "reminder-list-view",
+    REMINDER_LIST_MODAL="reminder-list-modal",
+    REMINDER_OPEN_REPO_ACTION="open-repo-action",
+    REMINDER_REMOVE_REPO_ACTION="remove-repo-reminder-action"
 }

--- a/github/handlers/ExecuteBlockActionHandler.ts
+++ b/github/handlers/ExecuteBlockActionHandler.ts
@@ -53,7 +53,8 @@ import { addIssueCommentsModal } from "../modals/addIssueCommentModal";
 import { GitHubIssuesStarterModal } from "../modals/getIssuesStarterModal";
 import { githubSearchModal } from "../modals/githubSearchModal";
 import { NewIssueStarterModal } from "../modals/newIssueStarterModal";
-import { unsubscribedPR } from "../persistance/remind";
+import { removeRepoReminder, unsubscribedPR } from "../persistance/remind";
+import { reminderModal } from "../modals/remindersModal";
 
 export class ExecuteBlockActionHandler {
 
@@ -1118,6 +1119,15 @@ export class ExecuteBlockActionHandler {
                     const message = `You have unsubscribed from repository [${repo} Pull Request #${number}](https://github.com/${repo}/pull/${number})`;
                     await sendNotification(this.read, this.modify, user, room as IRoom, message);
                     
+                }
+                
+                case ModalsEnum.REMINDER_REMOVE_REPO_ACTION : {
+                   const {value, user} = context.getInteractionData(); 
+                    await removeRepoReminder(this.read, this.persistence, value as string, user);
+                    
+                   const updatedReminderModal = await reminderModal({modify: this.modify, read:this.read, persistence: this.persistence, http: this.http, uikitcontext: context});
+
+                   return context.getInteractionResponder().updateModalViewResponse( updatedReminderModal);
                 }
             }
         } catch (error) {

--- a/github/modals/remindersModal.ts
+++ b/github/modals/remindersModal.ts
@@ -1,5 +1,5 @@
 import { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';
-import { ITextObject, TextObjectType } from '@rocket.chat/apps-engine/definition/uikit/blocks';
+import { ButtonStyle, ITextObject, TextObjectType } from '@rocket.chat/apps-engine/definition/uikit/blocks';
 import { IUIKitModalViewParam } from '@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder';
 import { ModalsEnum } from '../enum/Modals';
 import { SlashCommandContext } from '@rocket.chat/apps-engine/definition/slashcommands';
@@ -24,15 +24,26 @@ export async function reminderModal({ modify, read, persistence, http, slashcomm
             for (let repository of reminders.repos) {
                 block.addSectionBlock({
                     text: { text: `${repository}`, type: TextObjectType.PLAINTEXT },
-                    accessory: block.newButtonElement({
-                        actionId: ModalsEnum.OPEN_REPO_ACTION,
-                        text: {
-                            text: ModalsEnum.OPEN_REPO_LABEL,
-                            type: TextObjectType.PLAINTEXT
-                        },
-                        url: `https://github.com/${repository}`
-                    })
                 });
+
+                block.addActionsBlock({
+                    blockId:ModalsEnum.REMINDER_LIST_MODAL,
+
+                    elements:[    
+                        block.newButtonElement({
+                        actionId: ModalsEnum.OPEN_REPO_ACTION,
+                        text: block.newPlainTextObject("Open"),
+                        url:`https://github.com/${repository}`,
+                        style: ButtonStyle.PRIMARY,
+                        
+                    }),
+                    block.newButtonElement({
+                        actionId: ModalsEnum.REMINDER_REMOVE_REPO_ACTION,
+                        text: block.newPlainTextObject("Remove"),
+                        value: `${repository}`,
+                        style: ButtonStyle.DANGER,
+                    })]
+                })
 
                 block.addDividerBlock();
             }

--- a/github/persistance/remind.ts
+++ b/github/persistance/remind.ts
@@ -121,12 +121,19 @@ export async function getUserReminder(read:IRead,User:IUser):Promise<IReminder>{
 export async function removeRepoReminder(read:IRead,persistence:IPersistence,repository:string,User:IUser){
     const reminders = await getAllReminders(read);
     const idx = reminders.findIndex((u: IReminder) => u.userid === User.id);
+
+    if (idx === -1) {
+        return;
+    }
+
     const repoindex = reminders[idx].repos.findIndex((repo)=>repo == repository);
 
-    if (idx === -1 || repoindex === -1) {
+    if (repoindex === -1) {
         return;
     }
 
     reminders[idx].repos.splice(repoindex,1);
     await persistence.updateByAssociation(assoc, reminders);
 }
+
+

--- a/github/persistance/remind.ts
+++ b/github/persistance/remind.ts
@@ -82,7 +82,7 @@ export async function unsubscribedPR(read: IRead, persistence: IPersistence, rep
             prnum: [PullRequestNumber]
         })
     }
-    
+
     await persistence.updateByAssociation(assoc, reminders)
 }
 
@@ -120,11 +120,13 @@ export async function getUserReminder(read:IRead,User:IUser):Promise<IReminder>{
 
 export async function removeRepoReminder(read:IRead,persistence:IPersistence,repository:string,User:IUser){
     const reminders = await getAllReminders(read);
-
     const idx = reminders.findIndex((u: IReminder) => u.userid === User.id);
     const repoindex = reminders[idx].repos.findIndex((repo)=>repo == repository);
 
-    reminders[idx].repos.splice(repoindex,1);
+    if (idx === -1 || repoindex === -1) {
+        return;
+    }
 
-    await persistence.updateByAssociation(assoc, reminders);   
+    reminders[idx].repos.splice(repoindex,1);
+    await persistence.updateByAssociation(assoc, reminders);
 }

--- a/github/persistance/remind.ts
+++ b/github/persistance/remind.ts
@@ -117,3 +117,14 @@ export async function getUserReminder(read:IRead,User:IUser):Promise<IReminder>{
     const index = reminders.findIndex((reminder)=>reminder.userid === User.id);
     return reminders[index];
 }
+
+export async function removeRepoReminder(read:IRead,persistence:IPersistence,repository:string,User:IUser){
+    const reminders = await getAllReminders(read);
+
+    const idx = reminders.findIndex((u: IReminder) => u.userid === User.id);
+    const repoindex = reminders[idx].repos.findIndex((repo)=>repo == repository);
+
+    reminders[idx].repos.splice(repoindex,1);
+
+    await persistence.updateByAssociation(assoc, reminders);   
+}


### PR DESCRIPTION
## Acceptance Criteria fulfillment

- [x] Added "Remove" and "Open" buttons in the reminder modal for each repositry.

## Proposed changes (including videos or screenshots)
[Screencast from 2023-10-25 15-55-43.webm](https://github.com/RocketChat/Apps.Github22/assets/99081689/558ecfef-608f-40d1-85db-48a74b18a423)



