### PR TITLE
Fix issue of filtering the properties while sharing profile

### DIFF
--- a/github/handlers/ExecuteBlockActionHandler.ts
+++ b/github/handlers/ExecuteBlockActionHandler.ts
@@ -292,7 +292,7 @@ export class ExecuteBlockActionHandler {
                         const storeData = {
                             profileParams: profileInteractionData as string[]
                         }
-                    await this.persistence.updateByAssociation(new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, "ProfileShareParam"), storeData);
+                    await this.persistence.updateByAssociation(new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, "ProfileShareParam"), storeData, true);
                     }
                     break;
                 }
@@ -671,13 +671,13 @@ export class ExecuteBlockActionHandler {
                     return context.getInteractionResponder().openModalViewResponse(shareProfileMod);
                 }
                 case ModalsEnum.APPROVE_PULL_REQUEST_ACTION:{
-                    
+
                     let value: string = context.getInteractionData().value as string;
                     let splittedValues = value?.split(" ");
                     let { user } = await context.getInteractionData();
                     let { room} = await context.getInteractionData();
                     let accessToken = await getAccessTokenForUser(this.read, user, this.app.oauth2Config) as IAuthData;
-                    
+
                     if(splittedValues.length==2 && accessToken?.token){
                         let data={
                             "repo" : splittedValues[0],
@@ -1026,8 +1026,8 @@ export class ExecuteBlockActionHandler {
                             }
                     }
                     break;
-                } 
-                
+                }
+
                 case ModalsEnum.GITHUB_LOGIN_ACTION :{
                     const {user, room} = context.getInteractionData();
                     if(room){
@@ -1073,7 +1073,7 @@ export class ExecuteBlockActionHandler {
                     });
                     return context.getInteractionResponder().openModalViewResponse(newIssueModal);
                 }
-                
+
                 case ModalsEnum.TRIGGER_SEARCH_MODAL: {
                     const searchModal = await githubSearchModal({
                         modify: this.modify,
@@ -1096,13 +1096,13 @@ export class ExecuteBlockActionHandler {
 
                     const message = `You have unsubscribed from repository [${repo} Pull Request #${number}](https://github.com/${repo}/pull/${number})`;
                     await sendNotification(this.read, this.modify, user, room as IRoom, message);
-                    
+
                 }
-                
+
                 case ModalsEnum.REMINDER_REMOVE_REPO_ACTION : {
-                   const {value, user} = context.getInteractionData(); 
+                   const {value, user} = context.getInteractionData();
                     await removeRepoReminder(this.read, this.persistence, value as string, user);
-                    
+
                    const updatedReminderModal = await reminderModal({modify: this.modify, read:this.read, persistence: this.persistence, http: this.http, uikitcontext: context});
 
                    return context.getInteractionResponder().updateModalViewResponse( updatedReminderModal);


### PR DESCRIPTION
## Issue(s) 

Closes #148 

## Acceptance Criteria fulfillment

I have set the value to true in `this.persistence.updateByAssociation(new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, "ProfileShareParam"), storeData, true);` in case of `SHARE_PROFILE_PARAMS` such that if fixes the filtering of properties while sharing the profile 

## Proposed changes (including videos or screenshots)

[Screencast from 26-12-24 12:00:27 AM IST.webm](https://github.com/user-attachments/assets/9f74c87c-7970-4424-a599-156b9c59197b)